### PR TITLE
Upgrade to Laravel 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Trello notifications channel for Laravel 5.3
+# Trello notifications channel for Laravel 5.3+
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/laravel-notification-channels/trello.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/trello)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
@@ -9,7 +9,7 @@
 [![Code Coverage](https://img.shields.io/scrutinizer/coverage/g/laravel-notification-channels/trello/master.svg?style=flat-square)](https://scrutinizer-ci.com/g/laravel-notification-channels/trello/?branch=master)
 [![Total Downloads](https://img.shields.io/packagist/dt/laravel-notification-channels/trello.svg?style=flat-square)](https://packagist.org/packages/laravel-notification-channels/trello)
 
-This package makes it easy to create [Trello cards](https://developers.trello.com/) with Laravel 5.3.
+This package makes it easy to create [Trello cards](https://developers.trello.com/) with Laravel 5.3+.
 
 ## Contents
 

--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     "require": {
         "php": ">=5.6.4",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/notifications": "5.3.*",
-        "illuminate/support": "5.1.*|5.2.*|5.3.*"
+        "illuminate/notifications": "5.3.*|5.4.*",
+        "illuminate/support": "5.1.*|5.2.*|5.3.*|5.4.*"
     },
     "require-dev": {
         "mockery/mockery": "^0.9.5",


### PR DESCRIPTION
This upgrades the Trello Notification package to allow for Laravel 5.4 installs.