### PR TITLE
Adds method for adding comments when creating Trello card

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ class ProjectCreated extends Notification
             ->name("Trello Card Name")
             ->description("This is the Trello card description")
             ->top()
-            ->due('tomorrow');
+            ->due('tomorrow')
+            ->comments(['Don\'t forget to buy milk!', 'Brush your teeth twice a day']);
     }
 }
 ```
@@ -96,6 +97,8 @@ public function routeNotificationForTrello()
 - `bottom()`: Moves the Trello card to the bottom.
 - `position('')`: Accepts an integer for a specific Trello card position.
 - `due('')`: Accepts a string or DateTime object for the Trello card due date.
+- `comments([]|'')`: Accepts an array of comments or a comment string. Array of comment will be added to the Trello card individually.
+- `comment('')`: Accepts a comment string. Multiple comments can be added to the Trello card by calling this method multiple times.
 
 
 ## Changelog

--- a/patch.txt
+++ b/patch.txt
@@ -1,0 +1,163 @@
+diff --git a/src/Exceptions/CouldNotAddComment.php b/src/Exceptions/CouldNotAddComment.php
+index b9aa6634c1d41dbd69f6388a650d37f08b2cd968..bd70ce68b0116f75a80364dae868c95842436117 100644
+--- a/src/Exceptions/CouldNotAddComment.php
++++ b/src/Exceptions/CouldNotAddComment.php
+@@ -6,6 +6,6 @@ class CouldNotAddComment extends \Exception
+ {
+     public static function serviceRespondedWithAnError($response)
+     {
+-        return new static('Error adding comment. Trello responded with an error: `' . $response->getBody()->getContents() . '`');
++        return new static('Error adding comment. Trello responded with an error: `'.$response->getBody()->getContents().'`');
+     }
+ }
+diff --git a/src/TrelloChannel.php b/src/TrelloChannel.php
+index cc4b1e95259d73d4b29bddbd985a014ae671f55d..c9591282d4a8be9ae43d231df38219a8cc96ce76 100644
+--- a/src/TrelloChannel.php
++++ b/src/TrelloChannel.php
+@@ -3,11 +3,11 @@
+ namespace NotificationChannels\Trello;
+ 
+ use GuzzleHttp\Client;
+-use Illuminate\Notifications\Notification;
+ use Illuminate\Support\Arr;
++use Illuminate\Notifications\Notification;
+ use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
+-use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
+ use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
++use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
+ 
+ class TrelloChannel
+ {
+@@ -38,7 +38,7 @@ class TrelloChannel
+      */
+     public function send($notifiable, Notification $notification)
+     {
+-        if (!$routing = collect($notifiable->routeNotificationFor('Trello'))) {
++        if (! $routing = collect($notifiable->routeNotificationFor('Trello'))) {
+             return;
+         }
+ 
+@@ -49,7 +49,7 @@ class TrelloChannel
+         $trelloParameters = $notification->toTrello($notifiable)->toArray();
+         $trelloCardComments = $notification->toTrello($notifiable)->getComments();
+ 
+-        $response = $this->client->post(self::API_ENDPOINT . '?key=' . $this->key . '&token=' . $routing->get('token'), [
++        $response = $this->client->post(self::API_ENDPOINT.'?key='.$this->key.'&token='.$routing->get('token'), [
+             'form_params' => Arr::set($trelloParameters, 'idList', $routing->get('idList')),
+         ]);
+ 
+@@ -72,13 +72,13 @@ class TrelloChannel
+      */
+     public function addComments($notifiable, array $trelloCardComments, $response)
+     {
+-        if (!$routing = collect($notifiable->routeNotificationFor('Trello'))) {
++        if (! $routing = collect($notifiable->routeNotificationFor('Trello'))) {
+             return;
+         }
+ 
+         $cardId = json_decode($response->getBody()->getContents())->id;
+         foreach ($trelloCardComments as $comment) {
+-            $response = $this->client->post(self::API_ENDPOINT . $cardId . '/actions/comments?key=' . $this->key . '&token=' . $routing->get('token'), [
++            $response = $this->client->post(self::API_ENDPOINT.$cardId.'/actions/comments?key='.$this->key.'&token='.$routing->get('token'), [
+                 'form_params' => ['text' => $comment],
+             ]);
+             if ($response->getStatusCode() !== 200) {
+@@ -86,5 +86,4 @@ class TrelloChannel
+             }
+         }
+     }
+-
+ }
+diff --git a/src/TrelloMessage.php b/src/TrelloMessage.php
+index 96b06f1a13fd9fd2d82c3a9dfa888024edd8afea..61eee0e6ad8fdcbeecab0384c37e36388249b8d6 100644
+--- a/src/TrelloMessage.php
++++ b/src/TrelloMessage.php
+@@ -114,7 +114,7 @@ class TrelloMessage
+      */
+     public function due($due)
+     {
+-        if (!$due instanceof DateTime) {
++        if (! $due instanceof DateTime) {
+             $due = new DateTime($due);
+         }
+ 
+@@ -124,7 +124,7 @@ class TrelloMessage
+     }
+ 
+     /**
+-     * Set the cards comments from array or string
++     * Set the cards comments from array or string.
+      *
+      * @param array|string $comments
+      *
+@@ -132,7 +132,7 @@ class TrelloMessage
+      */
+     public function comments($comments)
+     {
+-        if (!is_array($comments)) {
++        if (! is_array($comments)) {
+             $this->comments = [$comments];
+         } else {
+             $this->comments = $comments;
+@@ -142,7 +142,7 @@ class TrelloMessage
+     }
+ 
+     /**
+-     * Add a comment to the card
++     * Add a comment to the card.
+      *
+      * @param array $comments
+      *
+@@ -156,7 +156,7 @@ class TrelloMessage
+     }
+ 
+     /**
+-     * Get comments to add to the card
++     * Get comments to add to the card.
+      *
+      * @return array|null
+      */
+diff --git a/tests/ChannelTest.php b/tests/ChannelTest.php
+index a06a042f150bc468f4ce1d38950b221699754f70..a8a33ae2fa1a84bcd2dc6b87c0cd2f359aea2d7d 100644
+--- a/tests/ChannelTest.php
++++ b/tests/ChannelTest.php
+@@ -2,16 +2,16 @@
+ 
+ namespace NotificationChannels\Trello\Test;
+ 
++use Mockery;
+ use GuzzleHttp\Client;
+ use GuzzleHttp\Psr7\Response;
++use Orchestra\Testbench\TestCase;
+ use Illuminate\Notifications\Notification;
+-use Mockery;
+-use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
+-use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
+-use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
+ use NotificationChannels\Trello\TrelloChannel;
+ use NotificationChannels\Trello\TrelloMessage;
+-use Orchestra\Testbench\TestCase;
++use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
++use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
++use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
+ 
+ class ChannelTest extends TestCase
+ {
+@@ -113,7 +113,6 @@ class ChannelTest extends TestCase
+         $channel = new TrelloChannel($client);
+         $channel->addComments(new TestNotifiable(), ['foo', 'bar'], $createCardResponse);
+     }
+-
+ }
+ 
+ class TestNotifiable
+diff --git a/tests/MessageTest.php b/tests/MessageTest.php
+index 61cc34ddce1db8b582d03cd67826c58fc00b5643..1135dae98e241cf92c05cd351d1bf6cb10d4910b 100644
+--- a/tests/MessageTest.php
++++ b/tests/MessageTest.php
+@@ -129,5 +129,4 @@ class MessageTest extends \PHPUnit_Framework_TestCase
+ 
+         $this->assertEquals(['bar'], $this->message->getComments());
+     }
+-
+ }

--- a/src/Exceptions/CouldNotAddComment.php
+++ b/src/Exceptions/CouldNotAddComment.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace NotificationChannels\Trello\Exceptions;
+
+class CouldNotAddComment extends \Exception
+{
+    public static function serviceRespondedWithAnError($response)
+    {
+        return new static('Error adding comment. Trello responded with an error: `' . $response->getBody()->getContents() . '`');
+    }
+}

--- a/src/Exceptions/CouldNotAddComment.php
+++ b/src/Exceptions/CouldNotAddComment.php
@@ -6,6 +6,6 @@ class CouldNotAddComment extends \Exception
 {
     public static function serviceRespondedWithAnError($response)
     {
-        return new static('Error adding comment. Trello responded with an error: `' . $response->getBody()->getContents() . '`');
+        return new static('Error adding comment. Trello responded with an error: `'.$response->getBody()->getContents().'`');
     }
 }

--- a/src/TrelloChannel.php
+++ b/src/TrelloChannel.php
@@ -3,9 +3,10 @@
 namespace NotificationChannels\Trello;
 
 use GuzzleHttp\Client;
-use Illuminate\Support\Arr;
-use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Arr;
+use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
+use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
 
 class TrelloChannel
@@ -15,10 +16,14 @@ class TrelloChannel
     /** @var Client */
     protected $client;
 
+    /** @var key trello key */
+    protected $key;
+
     /** @param Client $client */
     public function __construct(Client $client)
     {
         $this->client = $client;
+        $this->key = config('services.trello.key');
     }
 
     /**
@@ -29,27 +34,57 @@ class TrelloChannel
      *
      * @throws \NotificationChannels\Trello\Exceptions\InvalidConfiguration
      * @throws \NotificationChannels\Trello\Exceptions\CouldNotSendNotification
+     * @throws \NotificationChannels\Trello\Exceptions\CouldAddComment
      */
     public function send($notifiable, Notification $notification)
     {
-        if (! $routing = collect($notifiable->routeNotificationFor('Trello'))) {
+        if (!$routing = collect($notifiable->routeNotificationFor('Trello'))) {
             return;
         }
 
-        $key = config('services.trello.key');
-
-        if (is_null($key)) {
+        if (is_null($this->key)) {
             throw InvalidConfiguration::configurationNotSet();
         }
 
         $trelloParameters = $notification->toTrello($notifiable)->toArray();
+        $trelloCardComments = $notification->toTrello($notifiable)->getComments();
 
-        $response = $this->client->post(self::API_ENDPOINT.'?key='.$key.'&token='.$routing->get('token'), [
+        $response = $this->client->post(self::API_ENDPOINT . '?key=' . $this->key . '&token=' . $routing->get('token'), [
             'form_params' => Arr::set($trelloParameters, 'idList', $routing->get('idList')),
         ]);
 
         if ($response->getStatusCode() !== 200) {
             throw CouldNotSendNotification::serviceRespondedWithAnError($response);
         }
+
+        if ($trelloCardComments) {
+            $this->addComments($notifiable, $trelloCardComments, $response);
+        }
     }
+
+    /**
+     * Add comments to newly created card.
+     * @param mixed $notifiable
+     * @param array  $trelloCardComments array holding the comments to add
+     * @param Response $response           response object from the trello api
+     *
+     * @throws \NotificationChannels\Trello\Exceptions\CouldAddComment
+     */
+    public function addComments($notifiable, array $trelloCardComments, $response)
+    {
+        if (!$routing = collect($notifiable->routeNotificationFor('Trello'))) {
+            return;
+        }
+
+        $cardId = json_decode($response->getBody()->getContents())->id;
+        foreach ($trelloCardComments as $comment) {
+            $response = $this->client->post(self::API_ENDPOINT . $cardId . '/actions/comments?key=' . $this->key . '&token=' . $routing->get('token'), [
+                'form_params' => ['text' => $comment],
+            ]);
+            if ($response->getStatusCode() !== 200) {
+                throw CouldNotAddComment::serviceRespondedWithAnError($response);
+            }
+        }
+    }
+
 }

--- a/src/TrelloChannel.php
+++ b/src/TrelloChannel.php
@@ -3,11 +3,11 @@
 namespace NotificationChannels\Trello;
 
 use GuzzleHttp\Client;
-use Illuminate\Notifications\Notification;
 use Illuminate\Support\Arr;
+use Illuminate\Notifications\Notification;
 use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
-use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
+use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
 
 class TrelloChannel
 {
@@ -38,7 +38,7 @@ class TrelloChannel
      */
     public function send($notifiable, Notification $notification)
     {
-        if (!$routing = collect($notifiable->routeNotificationFor('Trello'))) {
+        if (! $routing = collect($notifiable->routeNotificationFor('Trello'))) {
             return;
         }
 
@@ -49,7 +49,7 @@ class TrelloChannel
         $trelloParameters = $notification->toTrello($notifiable)->toArray();
         $trelloCardComments = $notification->toTrello($notifiable)->getComments();
 
-        $response = $this->client->post(self::API_ENDPOINT . '?key=' . $this->key . '&token=' . $routing->get('token'), [
+        $response = $this->client->post(self::API_ENDPOINT.'?key='.$this->key.'&token='.$routing->get('token'), [
             'form_params' => Arr::set($trelloParameters, 'idList', $routing->get('idList')),
         ]);
 
@@ -72,13 +72,13 @@ class TrelloChannel
      */
     public function addComments($notifiable, array $trelloCardComments, $response)
     {
-        if (!$routing = collect($notifiable->routeNotificationFor('Trello'))) {
+        if (! $routing = collect($notifiable->routeNotificationFor('Trello'))) {
             return;
         }
 
         $cardId = json_decode($response->getBody()->getContents())->id;
         foreach ($trelloCardComments as $comment) {
-            $response = $this->client->post(self::API_ENDPOINT . $cardId . '/actions/comments?key=' . $this->key . '&token=' . $routing->get('token'), [
+            $response = $this->client->post(self::API_ENDPOINT.$cardId.'/actions/comments?key='.$this->key.'&token='.$routing->get('token'), [
                 'form_params' => ['text' => $comment],
             ]);
             if ($response->getStatusCode() !== 200) {
@@ -86,5 +86,4 @@ class TrelloChannel
             }
         }
     }
-
 }

--- a/src/TrelloMessage.php
+++ b/src/TrelloMessage.php
@@ -18,6 +18,9 @@ class TrelloMessage
     /** @var string|null */
     protected $due;
 
+    /** @var array|null */
+    protected $comments;
+
     /**
      * @param string $name
      *
@@ -111,13 +114,55 @@ class TrelloMessage
      */
     public function due($due)
     {
-        if (! $due instanceof DateTime) {
+        if (!$due instanceof DateTime) {
             $due = new DateTime($due);
         }
 
         $this->due = $due->format(DateTime::ATOM);
 
         return $this;
+    }
+
+    /**
+     * Set the cards comments from array or string
+     *
+     * @param array|string $comments
+     *
+     * @return $this
+     */
+    public function comments($comments)
+    {
+        if (!is_array($comments)) {
+            $this->comments = [$comments];
+        } else {
+            $this->comments = $comments;
+        }
+
+        return $this;
+    }
+
+    /**
+     * Add a comment to the card
+     *
+     * @param array $comments
+     *
+     * @return $this
+     */
+    public function comment($comment)
+    {
+        $this->comments[] = $comment;
+
+        return $this;
+    }
+
+    /**
+     * Get comments to add to the card
+     *
+     * @return array|null
+     */
+    public function getComments()
+    {
+        return $this->comments;
     }
 
     /**

--- a/src/TrelloMessage.php
+++ b/src/TrelloMessage.php
@@ -114,7 +114,7 @@ class TrelloMessage
      */
     public function due($due)
     {
-        if (!$due instanceof DateTime) {
+        if (! $due instanceof DateTime) {
             $due = new DateTime($due);
         }
 
@@ -124,7 +124,7 @@ class TrelloMessage
     }
 
     /**
-     * Set the cards comments from array or string
+     * Set the cards comments from array or string.
      *
      * @param array|string $comments
      *
@@ -132,7 +132,7 @@ class TrelloMessage
      */
     public function comments($comments)
     {
-        if (!is_array($comments)) {
+        if (! is_array($comments)) {
             $this->comments = [$comments];
         } else {
             $this->comments = $comments;
@@ -142,7 +142,7 @@ class TrelloMessage
     }
 
     /**
-     * Add a comment to the card
+     * Add a comment to the card.
      *
      * @param array $comments
      *
@@ -156,7 +156,7 @@ class TrelloMessage
     }
 
     /**
-     * Get comments to add to the card
+     * Get comments to add to the card.
      *
      * @return array|null
      */

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -2,16 +2,16 @@
 
 namespace NotificationChannels\Trello\Test;
 
+use Mockery;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
+use Orchestra\Testbench\TestCase;
 use Illuminate\Notifications\Notification;
-use Mockery;
-use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
-use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
-use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
 use NotificationChannels\Trello\TrelloChannel;
 use NotificationChannels\Trello\TrelloMessage;
-use Orchestra\Testbench\TestCase;
+use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
+use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
+use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
 
 class ChannelTest extends TestCase
 {
@@ -113,7 +113,6 @@ class ChannelTest extends TestCase
         $channel = new TrelloChannel($client);
         $channel->addComments(new TestNotifiable(), ['foo', 'bar'], $createCardResponse);
     }
-
 }
 
 class TestNotifiable

--- a/tests/ChannelTest.php
+++ b/tests/ChannelTest.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Response;
 use Illuminate\Notifications\Notification;
 use Mockery;
+use NotificationChannels\Trello\Exceptions\CouldNotAddComment;
 use NotificationChannels\Trello\Exceptions\CouldNotSendNotification;
 use NotificationChannels\Trello\Exceptions\InvalidConfiguration;
 use NotificationChannels\Trello\TrelloChannel;
@@ -39,6 +40,39 @@ class ChannelTest extends TestCase
     }
 
     /** @test */
+    public function it_can_send_a_notification_with_comments()
+    {
+        $this->app['config']->set('services.trello.key', 'TrelloKey');
+
+        $response = new Response(200, [], json_encode(['id' => 'NewTrelloCardId']));
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('post')
+            ->once()
+            ->with('https://api.trello.com/1/cards/?key=TrelloKey&token=NotifiableToken',
+                [
+                    'form_params' => [
+                        'name' => 'TrelloName',
+                        'desc' => 'TrelloDescription',
+                        'pos' => 'top',
+                        'due' => null,
+                        'idList' => 'TrelloListId',
+                    ],
+                ])
+            ->andReturn($response);
+        $client->shouldReceive('post')
+            ->once()
+            ->with('https://api.trello.com/1/cards/NewTrelloCardId/actions/comments?key=TrelloKey&token=NotifiableToken',
+                [
+                    'form_params' => [
+                        'text' => 'TrelloCommentFoo',
+                    ],
+                ])
+            ->andReturn($response);
+        $channel = new TrelloChannel($client);
+        $channel->send(new TestNotifiable(), new TestNotificationWithComment());
+    }
+
+    /** @test */
     public function it_throws_an_exception_when_it_is_not_configured()
     {
         $this->setExpectedException(InvalidConfiguration::class);
@@ -63,6 +97,23 @@ class ChannelTest extends TestCase
         $channel = new TrelloChannel($client);
         $channel->send(new TestNotifiable(), new TestNotification());
     }
+
+    /** @test */
+    public function it_throws_an_exception_when_it_could_not_add_the_comments()
+    {
+        $this->setExpectedException(CouldNotAddComment::class);
+
+        $this->app['config']->set('services.trello.key', 'TrelloKey');
+        $createCardResponse = new Response(200, [], json_encode(['id' => 'NewTrelloCardId']));
+        $createCommentResponse = new Response(500);
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('post')
+            ->once()
+            ->andReturn($createCommentResponse);
+        $channel = new TrelloChannel($client);
+        $channel->addComments(new TestNotifiable(), ['foo', 'bar'], $createCardResponse);
+    }
+
 }
 
 class TestNotifiable
@@ -81,14 +132,25 @@ class TestNotifiable
     }
 }
 
-
 class TestNotification extends Notification
 {
     public function toTrello($notifiable)
     {
         return
-            (new TrelloMessage('TrelloName'))
-                ->description('TrelloDescription')
-                ->top();
+        (new TrelloMessage('TrelloName'))
+            ->description('TrelloDescription')
+            ->top();
+    }
+}
+
+class TestNotificationWithComment extends Notification
+{
+    public function toTrello($notifiable)
+    {
+        return
+        (new TrelloMessage('TrelloName'))
+            ->description('TrelloDescription')
+            ->comments(['TrelloCommentFoo'])
+            ->top();
     }
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -129,5 +129,4 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(['bar'], $this->message->getComments());
     }
-
 }

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -91,4 +91,43 @@ class MessageTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(5, Arr::get($this->message->toArray(), 'pos'));
     }
+
+    /** @test */
+    public function it_can_set_comments_from_array()
+    {
+        $this->assertEquals(null, $this->message->getComments());
+
+        $this->message->comments(['foo', 'bar', 'baz']);
+
+        $this->assertEquals(['foo', 'bar', 'baz'], $this->message->getComments());
+    }
+
+    /** @test */
+    public function it_can_add_comment()
+    {
+        $this->assertEquals(null, $this->message->getComments());
+
+        $this->message->comment('foo');
+
+        $this->assertEquals(['foo'], $this->message->getComments());
+
+        $this->message->comment('bar');
+
+        $this->assertEquals(['foo', 'bar'], $this->message->getComments());
+    }
+
+    /** @test */
+    public function it_can_set_comments_array_from_string()
+    {
+        $this->assertEquals(null, $this->message->getComments());
+
+        $this->message->comments('foo');
+
+        $this->assertEquals(['foo'], $this->message->getComments());
+
+        $this->message->comments('bar');
+
+        $this->assertEquals(['bar'], $this->message->getComments());
+    }
+
 }


### PR DESCRIPTION
**Following methods are added:**
- `comments(array|string)` add one or multiple comments to the card created (use it when you have only one comment, or your comments are already collected in an array)
- `comment(string)` fill up comments array which will be added to the card created (use it when you have to iterate other obejct to fetch comment strings. This way you can add comments on by one)

- [x] Fully compatible with current release, adding comments are optional.
- [x] New features are covered with tests.
- [x] Methods are added to Readme.md with example 
- [x] New exception for failed commenting